### PR TITLE
Prevent rogue DLLs from inclusion in the installer

### DIFF
--- a/PolyDeploy/package.json
+++ b/PolyDeploy/package.json
@@ -17,6 +17,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
+    "cheerio": "^1.0.0-rc.2",
     "css-loader": "^0.28.7",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.2",

--- a/PolyDeploy/project.config.js
+++ b/PolyDeploy/project.config.js
@@ -6,6 +6,7 @@
         than MODULE_VERSION.
     */
     MODULE_NAME: 'PolyDeploy',
+    MODULE_DOMAIN: 'Modules',
     MODULE_VERSION: '00.06.00',
     WEBSITE_PATH: '../../Website/'
 };


### PR DESCRIPTION
Included changes to build chain to prevent DLLs not specified in the manifest from being included in the install zip.