### PR TITLE
Support "Managed Package" dependencies

### DIFF
--- a/PolyDeploy/Clients/Core/src/js/services/SessionDataService.js
+++ b/PolyDeploy/Clients/Core/src/js/services/SessionDataService.js
@@ -80,9 +80,9 @@
 
                             angular.forEach(pkg.Dependencies, function (dep) {
 
-                                if (dep.Type === 'package') {
+                                if (dep.IsPackageDependency) {
 
-                                    dependencies.push(dep.Value);
+                                    dependencies.push(dep.PackageName);
                                 }
                             });
 

--- a/PolyDeploy/Components/Deployment.cs
+++ b/PolyDeploy/Components/Deployment.cs
@@ -156,10 +156,10 @@ namespace Cantarus.Modules.PolyDeploy.Components
                 foreach (PackageDependency pd in pj.Dependencies)
                 {
                     // Is this dependency met by our deployment and is it a package dependency?
-                    if (pd.DeployMet && pd.Type.Equals("package"))
+                    if (pd.DeployMet && pd.IsPackageDependency)
                     {
                         // Try and find the install job that provides this dependency.
-                        InstallJob foundInstallDependency = FindInstallJobWithPackage(pd.Value, installJobs);
+                        InstallJob foundInstallDependency = FindInstallJobWithPackage(pd.PackageName, installJobs);
 
                         // Did we find it?
                         if (foundInstallDependency == null)

--- a/PolyDeploy/Components/InstallJob.cs
+++ b/PolyDeploy/Components/InstallJob.cs
@@ -55,9 +55,9 @@ namespace Cantarus.Modules.PolyDeploy.Components
             {
                 foreach (PackageDependency packageDependency in package.Dependencies)
                 {
-                    if (packageDependency.Type.Equals("package"))
+                    if (packageDependency.IsPackageDependency)
                     {
-                        if (FindDependency(packageDependency.Value, packageJobs))
+                        if (FindDependency(packageDependency.PackageName, packageJobs))
                         {
                             packageDependency.DeployMet = true;
                         }

--- a/PolyDeploy/Components/InstallJob.cs
+++ b/PolyDeploy/Components/InstallJob.cs
@@ -57,7 +57,7 @@ namespace Cantarus.Modules.PolyDeploy.Components
                 {
                     if (packageDependency.IsPackageDependency)
                     {
-                        if (FindDependency(packageDependency.PackageName, packageJobs))
+                        if (FindDependency(packageDependency, packageJobs))
                         {
                             packageDependency.DeployMet = true;
                         }
@@ -107,11 +107,23 @@ namespace Cantarus.Modules.PolyDeploy.Components
             }
         }
 
-        private bool FindDependency(string name, List<PackageJob> packageJobs)
+        private bool FindDependency(PackageDependency dependency, List<PackageJob> packageJobs)
         {
             foreach (PackageJob pj in packageJobs)
             {
-                if (pj.Name.ToLower().Equals(name.ToLower()))
+                if (!pj.Name.Equals(dependency.PackageName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                Version requiredVersion;
+                if (!Version.TryParse(dependency.DependencyVersion, out requiredVersion))
+                {
+                    return true;
+                }
+
+                Version packageVersion;
+                if (Version.TryParse(pj.VersionStr, out packageVersion) && packageVersion >= requiredVersion)
                 {
                     return true;
                 }

--- a/PolyDeploy/Components/PackageDependency.cs
+++ b/PolyDeploy/Components/PackageDependency.cs
@@ -11,6 +11,7 @@ namespace Cantarus.Modules.PolyDeploy.Components
 
         public bool IsPackageDependency { get; set; }
         public string PackageName { get; set; }
+        public string DependencyVersion { get; set; }
         internal bool DnnMet { get; set; }
         internal bool DeployMet { get; set; }
 
@@ -26,6 +27,7 @@ namespace Cantarus.Modules.PolyDeploy.Components
         {
             IsPackageDependency = PackageTypes.Contains(dependencyRoot.GetAttribute("type", ""));
             PackageName = dependencyRoot.Value;
+            DependencyVersion = dependencyRoot.GetAttribute("version", "");
             DnnMet = false;
             DeployMet = false;
 

--- a/PolyDeploy/Components/PackageDependency.cs
+++ b/PolyDeploy/Components/PackageDependency.cs
@@ -1,12 +1,16 @@
 ﻿using DotNetNuke.Services.Installer.Dependencies;
+using System;
+using System.Collections.Generic;
 using System.Xml.XPath;
 
 namespace Cantarus.Modules.PolyDeploy.Components
 {
     internal class PackageDependency
     {
-        public string Type { get; set; }
-        public string Value { get; set; }
+        private static readonly ISet<string> PackageTypes = new HashSet<string>(new [] { "PACKAGE", "MANAGEDPACKAGE" }, StringComparer.OrdinalIgnoreCase);
+
+        public bool IsPackageDependency { get; set; }
+        public string PackageName { get; set; }
         internal bool DnnMet { get; set; }
         internal bool DeployMet { get; set; }
 
@@ -20,8 +24,8 @@ namespace Cantarus.Modules.PolyDeploy.Components
 
         public PackageDependency(XPathNavigator dependencyRoot)
         {
-            Type = dependencyRoot.GetAttribute("type", "");
-            Value = dependencyRoot.Value;
+            IsPackageDependency = PackageTypes.Contains(dependencyRoot.GetAttribute("type", ""));
+            PackageName = dependencyRoot.Value;
             DnnMet = false;
             DeployMet = false;
 


### PR DESCRIPTION
DNN has two types of dependencies on packages, the "package" dependency, which
just ensures that a package is installed, and a "managedPackage" dependency,
which also includes a version that must be satisfied (these are typically used
for dependencies between JavaScript Library packages)