### PR TITLE
Fix build not finding System.Net.Http reference

### DIFF
--- a/PolyDeploy/PolyDeploy.csproj
+++ b/PolyDeploy/PolyDeploy.csproj
@@ -11,6 +11,7 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -83,14 +84,12 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Net.Http">
-      <HintPath>..\packages\DotNetNuke.WebApi.7.0.0\lib\System.Net.Http.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetNuke.WebApi.7.0.0\lib\System.Net.Http.Formatting.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.DynamicData" />

--- a/PolyDeploy/packages.config
+++ b/PolyDeploy/packages.config
@@ -4,5 +4,6 @@
   <package id="DotNetNuke.Web" version="7.0.0" targetFramework="net45" />
   <package id="DotNetNuke.Web.Client" version="7.4.2.216" targetFramework="net45" />
   <package id="DotNetNuke.WebApi" version="7.0.0" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="4.5.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I wasn't able to build with MSBuild until I fixed this reference.  Visual Studio showed the reference as missing, but magically found a version that would work.  This removes the need for the magic.