### PR TITLE
Use async/await in Deploy Client

### DIFF
--- a/DeployClient/API.cs
+++ b/DeployClient/API.cs
@@ -16,11 +16,12 @@ namespace DeployClient
 
         private static HttpClient BuildClient()
         {
-            HttpClient client = new HttpClient();
+            HttpClient client = new HttpClient()
+            {
+                BaseAddress = new Uri(new Uri(Program.Options.TargetUri), "DesktopModules/PolyDeploy/API/")
+            };
 
-            client.BaseAddress = new Uri(new Uri(Program.Options.TargetUri), "DesktopModules/PolyDeploy/API/");
             client.DefaultRequestHeaders.Add("x-api-key", APIKey);
-            client.Timeout = TimeSpan.FromSeconds(25);
 
             return client;
         }

--- a/DeployClient/DeployClient.csproj
+++ b/DeployClient/DeployClient.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
@@ -39,6 +41,9 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />

--- a/DeployClient/Program.cs
+++ b/DeployClient/Program.cs
@@ -134,7 +134,7 @@ namespace DeployClient
                 (bool installSuccess,  SortedList<string, dynamic> results) = await API.InstallAsync(sessionGuid);
                 if (!installSuccess)
                 {
-                    TimeSpan interval = new TimeSpan(0, 0, 0, 2);
+                    TimeSpan interval = TimeSpan.FromSeconds(2);
                     Dictionary<string, dynamic> response;
                     var successfullyReachedApi = false;
                     DateTime apiNotFoundAbortTime = DateTime.Now.AddSeconds(Options.InstallationStatusTimeout);

--- a/DeployClient/Program.cs
+++ b/DeployClient/Program.cs
@@ -1,9 +1,11 @@
-﻿using Cantarus.Libraries.Encryption;
+using Cantarus.Libraries.Encryption;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using System.Web;
 using System.Web.Script.Serialization;
 
@@ -22,7 +24,7 @@ namespace DeployClient
             InstallFailure = 4
         }
 
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             try
             {
@@ -31,7 +33,7 @@ namespace DeployClient
                 // Output start.
                 WriteLine("*** PolyDeploy Client ***");
                 WriteLine();
-                
+
                 // Do we have a target uri.
                 if (Options.TargetUri.Equals(string.Empty))
                 {
@@ -95,7 +97,7 @@ namespace DeployClient
                 WriteLine("Starting encryption and upload...");
 
                 // Get a session.
-                string sessionGuid = API.CreateSession();
+                string sessionGuid = await API.CreateSessionAsync();
 
                 WriteLine(string.Format("Got session: {0}", sessionGuid));
 
@@ -113,7 +115,7 @@ namespace DeployClient
                         {
                             Write("uploading...");
 
-                            API.AddPackageAsync(sessionGuid, es, Path.GetFileName(zipFile));
+                            await API.AddPackageAsync(sessionGuid, es, Path.GetFileName(zipFile));
                         }
 
                         WriteLine("done.");
@@ -129,22 +131,23 @@ namespace DeployClient
                 JavaScriptSerializer jsonSer = new JavaScriptSerializer();
 
                 // Start.
-                SortedList<string, dynamic> results = null;
-
-                if (!API.Install(sessionGuid, out results))
+                (bool installSuccess,  SortedList<string, dynamic> results) = await API.InstallAsync(sessionGuid);
+                if (!installSuccess)
                 {
                     TimeSpan interval = new TimeSpan(0, 0, 0, 2);
                     Dictionary<string, dynamic> response;
                     var successfullyReachedApi = false;
                     DateTime apiNotFoundAbortTime = DateTime.Now.AddSeconds(Options.InstallationStatusTimeout);
 
-                    // Attempt to get the status of the session from the remote api. 
+                    // Attempt to get the status of the session from the remote api.
                     // This can fail shortly after an installation as the api has not yet been initialised,
                     // so attempt to get it for the given timespan.
                     do
                     {
                         // Get whether we can reach the api
-                        successfullyReachedApi = API.GetSession(sessionGuid, out response);
+                        (bool getSessionSuccess, Dictionary<string, dynamic> getSessionResponse) = await API.GetSessionAsync(sessionGuid);
+                        successfullyReachedApi = getSessionSuccess;
+                        response = getSessionResponse;
 
                         if (!successfullyReachedApi)
                         {
@@ -161,7 +164,7 @@ namespace DeployClient
 
                     int status = -1;
                     string previousPrint = null;
-                    
+
                     DateTime abortTime = DateTime.Now.AddMinutes(10);
 
                     // Get the installation status from the API until it is complete or until the abort time is reached
@@ -202,7 +205,8 @@ namespace DeployClient
 
                         System.Threading.Thread.Sleep(interval);
 
-                        var success = API.GetSession(sessionGuid, out response);
+                        (bool success, Dictionary<string, dynamic> getSessionResponse) = await API.GetSessionAsync(sessionGuid);
+                        response = getSessionResponse;
 
                         // The api should not be returning a 404 status at this point
                         if (!success)
@@ -210,7 +214,7 @@ namespace DeployClient
                             throw new HttpException("Remote API returned status 404");
                         }
                     } while (status < 2 && DateTime.Now < abortTime);
-                    
+
                 }
                 else
                 {

--- a/DeployClient/Program.cs
+++ b/DeployClient/Program.cs
@@ -93,15 +93,15 @@ namespace DeployClient
                     WriteLine();
                 }
 
-                // Inform user of encryption.
-                WriteLine("Starting encryption and upload...");
-
                 // Get a session.
                 string sessionGuid = await API.CreateSessionAsync();
 
                 WriteLine(string.Format("Got session: {0}", sessionGuid));
 
                 DateTime startTime = DateTime.Now;
+
+                // Inform user of encryption.
+                WriteLine("Starting encryption and upload...");
 
                 foreach (string zipFile in zipFiles)
                 {

--- a/DeployClient/Program.cs
+++ b/DeployClient/Program.cs
@@ -298,10 +298,23 @@ namespace DeployClient
 
         private static void WriteException(Exception ex, int maxDepth = 10, int depth = 0)
         {
-            WriteLine(ex.Message);
+            WriteLine($"{ex.GetType()} | {ex.Message}");
             WriteLine(ex.StackTrace);
 
-            if (depth < maxDepth && ex.InnerException != null)
+            if (depth >= maxDepth)
+            {
+                return;
+            }
+
+            if (ex is AggregateException aggregate && aggregate.InnerExceptions.Any())
+            {
+                depth++;
+                foreach (Exception inner in aggregate.InnerExceptions)
+                {
+                    WriteException(inner, maxDepth, depth);
+                }
+            }
+            else if (ex.InnerException != null)
             {
                 depth++;
                 WriteException(ex.InnerException, maxDepth, depth);

--- a/DeployClient/packages.config
+++ b/DeployClient/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I was seeing some inconsistent errors around the `HttpClient` calls with cancelled tasks, so I adjusted the code to use `async`/`await` for those calls, and that appeared to address the issue.

I also did some minor cleanup and enhanced error logging in this PR.