### PR TITLE
Disable continue button when it doesn't make sense to continue

### DIFF
--- a/PolyDeploy/Clients/Deploy/src/js/controllers/UploadController.js
+++ b/PolyDeploy/Clients/Deploy/src/js/controllers/UploadController.js
@@ -4,6 +4,22 @@
         // Store for errors.
         $scope.errors = [];
 
+        // Should we be able to click continue?
+        $scope.canContinue = function () {
+
+            var canCon = true;
+
+            // Have we uploaded at least one thing and is everything uploaded?
+            if ($scope.uploader.getNotUploadedItems().length > 0
+                || $scope.uploader.queue.length < 1) {
+
+                // Can't continue.
+                canCon = false;
+            }
+
+            return canCon;
+        };
+
         // Wait for session guid.
         SessionService.sessionPromise.then(setupUploader);
 

--- a/PolyDeploy/Clients/Deploy/src/js/templates/upload.html
+++ b/PolyDeploy/Clients/Deploy/src/js/templates/upload.html
@@ -58,7 +58,7 @@
                 <div class="col-xs-12">
                     <h3>Controls</h3>
                     <button type="button" class="btn btn-success" ng-click="uploader.uploadAll()" ng-disabled="!uploader.getNotUploadedItems().length">Upload</button>
-                    <button type="button" class="btn btn-primary" ui-sref="install.summary">Continue</button>
+                    <button type="button" class="btn btn-primary" ng-disabled="!canContinue()" ui-sref="install.summary">Continue</button>
                 </div>
             </div>
             <!-- /Controls -->


### PR DESCRIPTION
Continue button is now only available when at least one item has been added to the upload queue and everything in the queue has been uploaded.

Fixes #15.