### PR TITLE
Prevent navigation to result page directly

### DIFF
--- a/PolyDeploy/Clients/Deploy/src/js/config.js
+++ b/PolyDeploy/Clients/Deploy/src/js/config.js
@@ -2,14 +2,12 @@
     function ($stateProvider, $urlRouterProvider, $httpProvider) {
 
         // Default route.
-        $urlRouterProvider.otherwise('/install/upload');
+        $urlRouterProvider.otherwise('/upload');
 
         // States.
         $stateProvider
             .state('install', {
-                url: '/install',
-                template: require('./templates/install.html'),
-                controller: 'InstallController'
+                template: require('./templates/install.html')
             })
             .state('install.upload', {
                 url: '/upload',
@@ -17,12 +15,10 @@
                 controller: require('./controllers/UploadController')
             })
             .state('install.summary', {
-                url: '/summary',
                 template: require('./templates/summary.html'),
                 controller: 'SummaryController'
             })
             .state('install.result', {
-                url: '/result',
                 template: require('./templates/result.html'),
                 controller: 'ResultController'
             })

--- a/PolyDeploy/Clients/Deploy/src/js/controllers/InstallController.js
+++ b/PolyDeploy/Clients/Deploy/src/js/controllers/InstallController.js
@@ -1,7 +1,0 @@
-﻿module.exports = ['$state',
-    function ($state) {
-
-        // Nothing here, go to upload.
-        $state.go('install.upload');
-
-    }];

--- a/PolyDeploy/Clients/Deploy/src/js/templates/install.html
+++ b/PolyDeploy/Clients/Deploy/src/js/templates/install.html
@@ -10,13 +10,6 @@
 </div>
 <!-- /Warnings-->
 
-<!-- Install Progression -->
-<div class="row">
-    <div class="col-xs-12">
-        <span>Install Progression</span>
-    </div>
-</div>
-<!-- /Install Progression -->
 <!-- Subview -->
 <div class="row">
     <div class="col-xs-12">

--- a/PolyDeploy/PolyDeploy.csproj
+++ b/PolyDeploy/PolyDeploy.csproj
@@ -231,7 +231,6 @@
     <Content Include="Images\polydeploy-logo-icon.png" />
     <Content Include="webpack.base.js" />
     <Content Include="Clients\Deploy\src\js\app.js" />
-    <Content Include="Clients\Deploy\src\js\controllers\InstallController.js" />
     <Content Include="Clients\Deploy\src\js\controllers\ResultController.js" />
     <Content Include="Clients\Deploy\src\js\controllers\SummaryController.js" />
     <Content Include="Clients\Deploy\src\js\controllers\UploadController.js" />


### PR DESCRIPTION
Stop direct navigation to anywhere but the upload to avoid the session installation being started before modules are added to it.

Fixes #46.